### PR TITLE
Remove the hard depdendency on Redis

### DIFF
--- a/buttercms-ruby.gemspec
+++ b/buttercms-ruby.gemspec
@@ -15,7 +15,6 @@ Gem::Specification.new do |s|
   s.license = 'MIT'
 
   s.add_dependency 'httparty', '~> 0.14', '>= 0.14.0'
-  s.add_dependency 'redis', '~> 3.0', '>= 3.0.0'
 
   s.add_development_dependency 'rspec', '~> 2.7'
   s.add_development_dependency 'webmock'

--- a/lib/buttercms/data_store_adapters/redis.rb
+++ b/lib/buttercms/data_store_adapters/redis.rb
@@ -1,9 +1,16 @@
+begin
+  require 'redis'
+rescue LoadError
+  puts "WARNING: redis >= 3.0.0 is required to use the redis data store."
+  raise
+end
+
 module ButterCMS
   module DataStoreAdapters
     class Redis
       def initialize(options)
         redis_url = options.first
-        
+
         @redis = ::Redis.new(url: redis_url)
       end
 

--- a/lib/buttercms/data_store_adapters/yaml.rb
+++ b/lib/buttercms/data_store_adapters/yaml.rb
@@ -1,3 +1,5 @@
+require 'yaml/store'
+
 module ButterCMS
   module DataStoreAdapters
     class Yaml


### PR DESCRIPTION
Use of Redis with the ButterCMS gem is optional, so a hard dependency doesn't make sense. It's not fun to get Redis bundled into your project if you're not using it.

This PR removes the hard dependency on Redis and moves the data store requires to where they are invoked, so the optional dependency on Redis can be enforced only if the user actually makes use of it.