### PR TITLE
Switch to Net::HTTP and raise exception on 404

### DIFF
--- a/buttercms-ruby.gemspec
+++ b/buttercms-ruby.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'httparty', '~> 0.14', '>= 0.14.0'
 
-  s.add_development_dependency 'rspec', '~> 2.7'
+  s.add_development_dependency 'rspec'
   s.add_development_dependency 'webmock'
   s.required_ruby_version = '>= 1.9.3'
 

--- a/buttercms-ruby.gemspec
+++ b/buttercms-ruby.gemspec
@@ -14,8 +14,6 @@ Gem::Specification.new do |s|
   s.homepage = "https://buttercms.com/docs"
   s.license = 'MIT'
 
-  s.add_dependency 'httparty', '~> 0.14', '>= 0.14.0'
-
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'webmock'
   s.required_ruby_version = '>= 1.9.3'

--- a/lib/buttercms-ruby.rb
+++ b/lib/buttercms-ruby.rb
@@ -2,6 +2,8 @@ require 'json'
 require 'ostruct'
 require 'logger'
 
+require "buttercms/errors"
+
 require_relative 'buttercms/version'
 require_relative 'buttercms/hash_to_object'
 
@@ -82,6 +84,11 @@ module ButterCMS
 
         http.request(request)
       end
+
+    case response
+    when Net::HTTPNotFound
+      raise ::ButterCMS::NotFound, JSON.parse(response.body)["detail"]
+    end
 
     response.body
   end

--- a/lib/buttercms-ruby.rb
+++ b/lib/buttercms-ruby.rb
@@ -72,7 +72,6 @@ module ButterCMS
       read_timeout: 5.0,
       ssl_timeout:  2.0,
       use_ssl:      @api_url.scheme == "https",
-      verify_mode:  OpenSSL::SSL::VERIFY_NONE,
     }
 
     response =

--- a/lib/buttercms/errors.rb
+++ b/lib/buttercms/errors.rb
@@ -1,0 +1,9 @@
+module ButterCMS
+  # Error is the top level error raised by ButterCMS
+  class Error < StandardError
+  end
+
+  # NotFound is raised when a resource cannot be found
+  class NotFound < Error
+  end
+end

--- a/lib/buttercms/errors/buttercms_error.rb
+++ b/lib/buttercms/errors/buttercms_error.rb
@@ -1,4 +1,0 @@
-module ButterCMS
-  class ButterCMSError < StandardError
-  end
-end

--- a/spec/lib/butter-ruby_spec.rb
+++ b/spec/lib/butter-ruby_spec.rb
@@ -4,7 +4,7 @@ describe ButterCMS do
   describe '.request' do
     context 'with an api token' do
       before do
-        ButterCMS.stub(:api_token).and_return('test123')
+        allow(ButterCMS).to receive(:api_token).and_return('test123')
       end
 
       it 'should make an api request' do

--- a/spec/lib/butter-ruby_spec.rb
+++ b/spec/lib/butter-ruby_spec.rb
@@ -8,8 +8,11 @@ describe ButterCMS do
       end
 
       it 'should make an api request' do
-        stub_request(:get, 'https://api.buttercms.com/v2?auth_token=test123').to_return(body: JSON.generate({data: {test: 'test'}}))
-        expect{ ButterCMS.request('') }.to_not raise_error
+        request = stub_request(:get, "https://api.buttercms.com/v2?auth_token=test123")
+          .to_return(body: JSON.generate({data: {test: 'test'}}))
+
+        ButterCMS.request('')
+        expect(request).to have_been_made
       end
     end
 

--- a/spec/lib/butter-ruby_spec.rb
+++ b/spec/lib/butter-ruby_spec.rb
@@ -21,5 +21,18 @@ describe ButterCMS do
         expect{ ButterCMS.request() }.to raise_error(ArgumentError)
       end
     end
+
+    it "raises NotFound on 404" do
+      allow(ButterCMS).to receive(:api_token).and_return("test123")
+
+      request = stub_request(:get, %r{/posts/slug})
+        .with(query: { auth_token: "test123" })
+        .to_return(status: 404, body: '{"detail":"Not found."}')
+
+      expect { ButterCMS.request("/posts/slug") }
+        .to raise_error(ButterCMS::NotFound)
+
+      expect(request).to have_been_made
+    end
   end
 end

--- a/spec/lib/buttercms/butter_resource_spec.rb
+++ b/spec/lib/buttercms/butter_resource_spec.rb
@@ -1,14 +1,14 @@
 require 'spec_helper'
 
 describe ButterCMS::ButterResource do
-  describe '.all' do
-    before do
-      ButterCMS.stub(:token).and_return('test123')
-      ButterCMS.stub(:request).and_return({"data" => [{"attribute" => 'test'}]})
+  before do
+    allow(ButterCMS).to receive(:token).and_return('test123')
+    allow(ButterCMS).to receive(:request).and_return({"data" => [{"attribute" => 'test'}]})
 
-      ButterCMS::ButterResource.stub(:resource_path).
-        and_return('')
-    end
+    allow(ButterCMS::ButterResource).to receive(:resource_path).and_return('')
+  end
+
+  describe '.all' do
 
     it 'should make a request with the correct endpoint' do
       expect(ButterCMS).to receive(:request).with('/', {})
@@ -23,14 +23,6 @@ describe ButterCMS::ButterResource do
   end
 
   describe '.find' do
-    before do
-      ButterCMS.stub(:token).and_return('test123')
-      ButterCMS.stub(:request).and_return({"data" => {"attribute" => 'test'}})
-
-      ButterCMS::ButterResource.stub(:resource_path).
-        and_return('')
-    end
-
     it 'should make a request with the correct endpoint' do
       expect(ButterCMS).to receive(:request).with('/1', {})
       ButterCMS::ButterResource.find(1)


### PR DESCRIPTION
When updating to `buttercms-ruby` 1.2.0 on [Dead Man's Snitch](https://deadmanssnitch.com) from 1.1.1 I noticed that the gem had switched from rest-client to HTTParty. This added HTTParty as a new dependency for our application. I'm a pretty opinionated in that libraries should depend on Net::HTTP where possible. We already have 3 different HTTP clients as dependencies and I didn't want to add another one.

Looking at what `buttercms-ruby` is doing it was easy enough to swap in Net::HTTP partially based on our work on [Snitch](github.com/deadmanssnitch/snitcher).

Also during this upgrade we found a change in behavior where `ButterCMS::Post.find("missing_slug")` no longer raised an exception that we were depending on to render a 404 to our users. This reintroduced this behavior but does so with an exception that is namespaced to `ButterCMS` which keeps users of the library from having to know about the implementation.

Fixes #3 