### PR TITLE
Expose items for ButterCollection to use array methods

### DIFF
--- a/lib/buttercms/butter_collection.rb
+++ b/lib/buttercms/butter_collection.rb
@@ -2,6 +2,7 @@ module ButterCMS
   class ButterCollection
     include Enumerable
 
+    attr_reader :items
     attr_reader :meta
 
     def initialize(klass, json)

--- a/lib/buttercms/version.rb
+++ b/lib/buttercms/version.rb
@@ -1,3 +1,3 @@
 module ButterCMS
-  VERSION = '1.5'
+  VERSION = '1.6'
 end

--- a/spec/lib/buttercms/butter_collection_spec.rb
+++ b/spec/lib/buttercms/butter_collection_spec.rb
@@ -4,6 +4,12 @@ describe ButterCMS::ButterCollection do
   let(:json) { {"data" => ["foo"], "meta" => {}} }
   let(:klass) { double('klass', :new => 'bar') }
 
+  it 'implements #items' do
+    collection = ButterCMS::ButterCollection.new(klass, json)
+
+    expect(collection.items).to match_array(["bar"])
+  end
+
   it 'implements #meta' do
     collection = ButterCMS::ButterCollection.new(klass, json)
 


### PR DESCRIPTION
The data list of the `ButterCollection` is hidden in the object, which only exposes `each` and `meta`. This is pretty restrictive. We have cases for using `map`, `[x..-1]`, etc. We're currently having to do `to_a` or `instance_variable_get` in every case. It would be nicer for the API to expose the list itself.