### PR TITLE
Fix Marshal.load on a ButterCollection not restoring ButterResource dynamic methods

### DIFF
--- a/lib/buttercms/version.rb
+++ b/lib/buttercms/version.rb
@@ -1,3 +1,3 @@
 module ButterCMS
-  VERSION = '1.6'
+  VERSION = '1.7'
 end

--- a/spec/lib/buttercms/butter_collection_spec.rb
+++ b/spec/lib/buttercms/butter_collection_spec.rb
@@ -21,4 +21,20 @@ describe ButterCMS::ButterCollection do
 
     expect(collection.count).to eq 1
   end
+
+  # Marshal.load (used by Rails for caching) was not restoring the ButterResource's dynamic methods
+  # See https://github.com/ButterCMS/buttercms-ruby/issues/13
+  describe 'marshal load' do
+    subject { described_class.new(ButterCMS::ButterResource, 'data' => [{ 'name' => 'Test Name', 'description' => 'Test Description' }]) }
+
+    it 'restores the ButterResource dynamic methods' do
+      collection = Marshal.load(Marshal.dump(subject))
+      resource = collection.first
+
+      aggregate_failures do
+        expect(resource.name).to eq('Test Name')
+        expect(resource.description).to eq('Test Description')
+      end
+    end
+  end
 end

--- a/spec/lib/buttercms/butter_resource_spec.rb
+++ b/spec/lib/buttercms/butter_resource_spec.rb
@@ -8,6 +8,17 @@ describe ButterCMS::ButterResource do
     allow(ButterCMS::ButterResource).to receive(:resource_path).and_return('')
   end
 
+  describe 'auto-generated methods' do
+    let(:resource) { described_class.new('data' => { 'name' => 'Test Name', 'description' => 'Test Description' }) }
+
+    it 'creates attribute reader methods for data pairs' do
+      aggregate_failures do
+        expect(resource.name).to eq('Test Name')
+        expect(resource.description).to eq('Test Description')
+      end
+    end
+  end
+
   describe '.all' do
 
     it 'should make a request with the correct endpoint' do


### PR DESCRIPTION
Adds `marshal_dump` and `marshal_load` to the `ButterResource` for ensuring that the marshal'd data appropriately restores the dynamically generated attribute readers.

Fixes #13