### PR TITLE
chore: change URI.encode to URI.encode_www_form

### DIFF
--- a/lib/buttercms-ruby.rb
+++ b/lib/buttercms-ruby.rb
@@ -71,7 +71,7 @@ module ButterCMS
       query[:test] = 1
     end
 
-    path = "#{@api_url.path}#{URI.encode(path)}?#{URI.encode_www_form(query)}"
+    path = "#{@api_url.path}#{URI.encode_www_form(path)}?#{URI.encode_www_form(query)}"
 
     response =
       Net::HTTP.start(@api_url.host, @api_url.port, http_options) do |http|


### PR DESCRIPTION
fixes #17

I see @hcatlin beat me to the issue, but this should fix the error messages.

https://docs.knapsackpro.com/2020/uri-escape-is-obsolete-percent-encoding-your-query-string