### PR TITLE
Path is a string, not a Hash

### DIFF
--- a/lib/buttercms-ruby.rb
+++ b/lib/buttercms-ruby.rb
@@ -71,7 +71,7 @@ module ButterCMS
       query[:test] = 1
     end
 
-    path = "#{@api_url.path}#{URI.encode_www_form(path)}?#{URI.encode_www_form(query)}"
+    path = "#{@api_url.path}#{URI.encode_www_form_component(path)}?#{URI.encode_www_form(query)}"
 
     response =
       Net::HTTP.start(@api_url.host, @api_url.port, http_options) do |http|

--- a/lib/buttercms-ruby.rb
+++ b/lib/buttercms-ruby.rb
@@ -71,7 +71,13 @@ module ButterCMS
       query[:test] = 1
     end
 
-    path = "#{@api_url.path}#{URI.encode_www_form_component(path)}?#{URI.encode_www_form(query)}"
+    # If the user has passed in a "/" leading path, don't interpret that
+    # as wanting to get rid of the API prefix
+    if path.start_with?("/")
+      path = path[1..-1]
+    end
+
+    path = Pathname.new(@api_url.path).join(path).to_s + "?#{URI.encode_www_form(query)}"
 
     response =
       Net::HTTP.start(@api_url.host, @api_url.port, http_options) do |http|

--- a/spec/lib/butter-ruby_spec.rb
+++ b/spec/lib/butter-ruby_spec.rb
@@ -14,6 +14,22 @@ describe ButterCMS do
         ButterCMS.request('')
         expect(request).to have_been_made
       end
+
+      it "should properly escape paths" do
+        request = stub_request(
+          :get,
+          "https://api.buttercms.com/v2/pages/*/homepage%20en?auth_token=test123"
+        ).to_return(body: JSON.generate({data: {test: 'test'}}))
+
+        # support leading slashes
+        ButterCMS.request('/pages/*/homepage en')
+
+        # and no leading slashes
+        ButterCMS.request('pages/*/homepage en')
+
+
+        expect(request).to have_been_made.twice
+      end
     end
 
     context 'without an api token' do


### PR DESCRIPTION
This is to address #19 

Unfortunately our suggested code change doesn't work, as the path is a string, not a Hash.

Running the specs locally on main vs this branch, I can confirm passage locally.

```

ButterCMS
  .request
    raises NotFound on 404
    with an api token
      should make an api request
    without an api token
      should throw an argument error

ButterCMS::ButterCollection
  implements #items
  implements #meta
  implements #count
  marshal load
    restores the ButterResource dynamic methods

ButterCMS::ButterResource
  auto-generated methods
    creates attribute reader methods for data pairs
  .all
    should make a request with the correct endpoint
    should return a collection
  .find
    should make a request with the correct endpoint
    should return one object

ButterCMS::Content
  has meta and collection info

ButterCMS::HashToObject
  .convert
    converts hash to object

Finished in 0.01827 seconds (files took 0.16291 seconds to load)
14 examples, 0 failures
```