### PR TITLE
fix uninitialized constant ButterCMS::Pathname

### DIFF
--- a/lib/buttercms-ruby.rb
+++ b/lib/buttercms-ruby.rb
@@ -3,6 +3,7 @@ require 'ostruct'
 require 'logger'
 require 'uri'
 require 'net/http'
+require 'pathname'
 
 require "buttercms/errors"
 require 'buttercms/version'

--- a/lib/buttercms/version.rb
+++ b/lib/buttercms/version.rb
@@ -1,3 +1,3 @@
 module ButterCMS
-  VERSION = '2.1'
+  VERSION = '2.2'
 end


### PR DESCRIPTION
Fix the error:
```
Traceback (most recent call last):
        6: from C:/Ruby27-x64/bin/irb:23:in `load'
        4: from (irb):4
        3: from C:/Ruby27-x64/lib/ruby/gems/2.7.0/gems/buttercms-ruby-2.1/lib/buttercms/page.rb:14:in `get'        
        2: from C:/Users/orlyk/Documents/Work/buttercms-ruby/lib/buttercms-ruby.rb:105:in `request'
        1: from C:/Users/orlyk/Documents/Work/buttercms-ruby/lib/buttercms-ruby.rb:80:in `api_request'
NameError (uninitialized constant ButterCMS::Pathname)
```
that comes up when user tries to get content (for example page)
