### PR TITLE
Support secure redis connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,10 @@ ButterCMS::data_store = :yaml, "/File/Path/For/buttercms.store"
 # Use Redis
 ButterCMS::data_store = :redis, ENV['REDIS_URL']
 
+# Use Redis your own redis instance (passing in redis instance)
+redis_instance = Redis.new(url: ENV['REDIS_SECURE_URL'], ssl_params: { ca_file: "/path/to/ca.crt" })
+ButterCMS::data_store = :redis, redis_instance
+
 # Set logger (optional)
 ButterCMS::logger = MyLogger.new
 ```

--- a/README.md
+++ b/README.md
@@ -134,9 +134,8 @@ ButterCMS::data_store = :yaml, "/File/Path/For/buttercms.store"
 # Use Redis
 ButterCMS::data_store = :redis, ENV['REDIS_URL']
 
-# Use Redis your own redis instance (passing in redis instance)
-redis_instance = Redis.new(url: ENV['REDIS_SECURE_URL'], ssl_params: { ca_file: "/path/to/ca.crt" })
-ButterCMS::data_store = :redis, redis_instance
+# Use Redis over ssl store
+ButterCMS.data_store = :redis_ssl, ENV["REDIS_URL"], { ca_file: "/path/to/ca.crt" }
 
 # Set logger (optional)
 ButterCMS::logger = MyLogger.new

--- a/lib/buttercms-ruby.rb
+++ b/lib/buttercms-ruby.rb
@@ -59,6 +59,9 @@ module ButterCMS
     when :redis
       require_relative 'buttercms/data_store_adapters/redis'
       @data_store = ButterCMS::DataStoreAdapters::Redis.new(options)
+    when :redis_ssl
+      require_relative 'buttercms/data_store_adapters/redis_ssl'
+      @data_store = ButterCMS::DataStoreAdapters::RedisSSL.new(options)
     else
       raise ArgumentError.new "Invalid ButterCMS data store #{strategy}"
     end
@@ -132,14 +135,14 @@ module ButterCMS
 
     return JSON.parse(result)
   end
-  
+
   def self.write_request(path, options = {})
     raise ArgumentError.new "Please set your write API token" unless write_api_token
     result = write_api_request(path, options)
 
     return JSON.parse(result)
   end
-  
+
   def self.write_api_request(path, options = {})
     query = options.dup
     token_for_request = query.delete(:auth_token) || write_api_token
@@ -177,9 +180,9 @@ module ButterCMS
 
     response.body
   end
-  
+
   private
-  
+
   def self.http_options
     {
       open_timeout: open_timeout || 2.0,

--- a/lib/buttercms/data_store_adapters/redis.rb
+++ b/lib/buttercms/data_store_adapters/redis.rb
@@ -9,9 +9,13 @@ module ButterCMS
   module DataStoreAdapters
     class Redis
       def initialize(options)
-        redis_url = options.first
+        redis_param = options.first
 
-        @redis = ::Redis.new(url: redis_url)
+        if redis_param.is_a?(String)
+          @redis = ::Redis.new(url: redis_param)
+        else # redis instance was passed in
+          @redis = redis_param
+        end
       end
 
       def set(key, value)

--- a/lib/buttercms/data_store_adapters/redis.rb
+++ b/lib/buttercms/data_store_adapters/redis.rb
@@ -9,13 +9,9 @@ module ButterCMS
   module DataStoreAdapters
     class Redis
       def initialize(options)
-        redis_param = options.first
+        redis_url = options.first
 
-        if redis_param.is_a?(String)
-          @redis = ::Redis.new(url: redis_param)
-        else # redis instance was passed in
-          @redis = redis_param
-        end
+        @redis = ::Redis.new(url: redis_url)
       end
 
       def set(key, value)

--- a/lib/buttercms/data_store_adapters/redis_ssl.rb
+++ b/lib/buttercms/data_store_adapters/redis_ssl.rb
@@ -1,0 +1,27 @@
+begin
+  require 'redis'
+rescue LoadError
+  puts "WARNING: redis >= 3.0.0 is required to use the redis data store."
+  raise
+end
+
+module ButterCMS
+  module DataStoreAdapters
+    class RedisSSL
+      def initialize(options)
+        redis_url = options.first
+        ssl_params = options.second && Hash.new(options.second)
+
+        @redis = ::Redis.new(url: redis_url, ssl_params:)
+      end
+
+      def set(key, value)
+        @redis.set(key, value)
+      end
+
+      def get(key)
+        @redis.get(key)
+      end
+    end
+  end
+end

--- a/lib/buttercms/data_store_adapters/redis_ssl.rb
+++ b/lib/buttercms/data_store_adapters/redis_ssl.rb
@@ -10,7 +10,7 @@ module ButterCMS
     class RedisSSL
       def initialize(options)
         redis_url = options.first
-        ssl_params = options.second && Hash.new(options.second)
+        ssl_params = options.second && Hash[options.second]
 
         @redis = ::Redis.new(url: redis_url, ssl_params:)
       end


### PR DESCRIPTION
**Problem:**
The current Redis data store adapter does not support TLS connections. It does not support setting any of the connection parameters either.

**Solution:**
We could have exposed some of the connection properties in our initialiser. But instead of doing piecemeal, we are purposing to allow gem users to specify their own pre-initialised redis instance.