### PR TITLE
chore: add release and publish actions

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,31 @@
+# This workflow opens and updates a pull request with a new package version
+# based on code changes.
+
+# The pull request updates the version in version.rb, updates the changelog
+# and creates release tags.
+
+# For more information, see https://github.com/marketplace/actions/release-please-action
+
+
+on:
+  push:
+    branches:
+      - master
+  
+permissions:
+  contents: write
+  pull-requests: write
+
+name: release-please
+
+jobs:
+  release-please:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: google-github-actions/release-please-action@v3.7.10
+        with:
+          release-type: ruby
+          package-name: release-please-action
+          version-file: "lib/buttercms/version.rb"
+          pull-request-title-pattern: "chore(release): ${version}"
+          pull-request-header: ":robot: Merge this PR to release a new version"

--- a/.github/workflows/rubygems-publish.yml
+++ b/.github/workflows/rubygems-publish.yml
@@ -19,12 +19,12 @@ jobs:
           ruby-version: "2.7"
       - run: gem build
       # add RubyGems API key into the credentials file and update permissions
-      - run: |
+      - env:
+          RUBYGEMS_API_KEY: ${{ secrets.RUBYGEMS_API_KEY }}
+        run: |
           cat << EOF > ~/.gem/credentials
           ---
           :rubygems_api_key: ${RUBYGEMS_API_KEY}
           EOF
           chmod 0600 ~/.gem/credentials
-        env:
-          RUBYGEMS_API_KEY: ${{ secrets.RUBYGEMS_API_KEY }}
-      - run: gem push *.gem
+      - run: gem push ./*.gem

--- a/.github/workflows/rubygems-publish.yml
+++ b/.github/workflows/rubygems-publish.yml
@@ -1,0 +1,30 @@
+# This workflow will publish a gem to rubygems.org when a release is created
+
+name: Publish Gem
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  publish:
+    if: contains(github.event.head_commit.message, 'chore(release)')
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: actions/checkout@v3.5.3
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "2.7"
+      - run: gem build
+      # add RubyGems API key into the credentials file and update permissions
+      - run: |
+          cat << EOF > ~/.gem/credentials
+          ---
+          :rubygems_api_key: ${RUBYGEMS_API_KEY}
+          EOF
+          chmod 0600 ~/.gem/credentials
+        env:
+          RUBYGEMS_API_KEY: ${{ secrets.RUBYGEMS_API_KEY }}
+      - run: gem push *.gem

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,11 @@
+# Contributing
+
+## Release and publish a new SDK version
+
+This SDK uses the [`release-please` GitHub Action](https://github.com/google-github-actions/release-please-action) to automate preparing new versions for release.
+
+When you are ready to release a new SDK version, make sure that all your code changes have been approved and merged into the `master` branch and that your code is working. The `release-please` tool generates a changelog based on **commit messages; these messages should follow the [Conventional Commits](https://conventionalcommits.org) specification in order for the changelog to reflect all code changes accurately**. Otherwise, you would need to update the changelog manually before each release.
+
+The `release-please` action opens and maintains a GitHub pull request with changes relevant to a new version release. Approve this pull request to release a new version of the SDK.
+
+After the release, the new version is automatically published into the RubyGems repository (see the package [here](https://rubygems.org/gems/buttercms-ruby)).


### PR DESCRIPTION
❗ In order for the release tool to work, it is necessary to:

- tag the latest release commit in the master branch with the tag v2.4 (right now this is the latest SDK version). :heavy_check_mark: 

- make sure that the field "Allow GitHub Actions to create and approve pull requests" in Settings > Actions > General is checked :heavy_check_mark:  :exclamation: 
:exclamation: In order for the Rubygems publish tool to work, a Rubygems API key (RUBYGEMS_API_KEY) has to be generated in the Rubygems repository and added to GitHub Secrets. :exclamation:

After these changes been aproved and merged into the master branch, the automatic release-please pull request will be opened next time when someone adds something releasable with a conventional commit message (i.e. with a prefix fix: or feat:).